### PR TITLE
[JENKINS-29370] Add the concept of an authentication token context

### DIFF
--- a/src/main/java/jenkins/authentication/tokens/api/AuthenticationTokenContext.java
+++ b/src/main/java/jenkins/authentication/tokens/api/AuthenticationTokenContext.java
@@ -1,0 +1,204 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015, CloudBees, Inc., Stephen Connolly.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.authentication.tokens.api;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import net.jcip.annotations.NotThreadSafe;
+import net.jcip.annotations.ThreadSafe;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * The context within which an authentication token will be used.
+ *
+ * @param <T> the type of token
+ * @since 1.2
+ */
+@ThreadSafe
+public final class AuthenticationTokenContext<T> {
+    /**
+     * The base class
+     */
+    @NonNull
+    private final Class<T> tokenClass;
+    /**
+     * The optional purposes for which the token will be used.
+     */
+    @CheckForNull
+    private final Map<Object, Object> purposes;
+
+    /**
+     * Creates a basic context for any purpose.
+     *
+     * @param tokenClass the type of token.
+     */
+    public AuthenticationTokenContext(@NonNull Class<T> tokenClass) {
+        this(tokenClass, null);
+    }
+
+    /**
+     * Creates a context with the specified purposes.
+     *
+     * @param tokenClass the type of token.
+     * @param purposes   the purposes.
+     */
+    private AuthenticationTokenContext(@NonNull Class<T> tokenClass, @CheckForNull Map<Object, Object> purposes) {
+        this.tokenClass = tokenClass;
+        this.purposes = purposes;
+    }
+
+    /**
+     * Creates a {@link Builder} for contexts of the specified token type.
+     *
+     * @param tokenClass the type of token.
+     * @param <T>        the type of token.
+     * @return a {@link Builder} instance.
+     */
+    public static <T> Builder<T> builder(@NonNull Class<T> tokenClass) {
+        return new Builder<T>(tokenClass);
+    }
+
+    /**
+     * Returns the type of token.
+     *
+     * @return the type of token.
+     */
+    @NonNull
+    public Class<T> getTokenClass() {
+        return tokenClass;
+    }
+
+    /**
+     * Checks if the context specifies the supplied purpose and matches against the valid values.
+     *
+     * @param purpose     the purpose.
+     * @param validValues the valid values that the purpose must match if specified.
+     * @return {@code true} if either the purpose is not specified or the purpose is specified and is equal
+     * to one of the specified values.
+     */
+    public boolean canHave(@NonNull Object purpose, Object... validValues) {
+        if (purposes == null || !purposes.containsKey(purpose)) {
+            // we do not have a counter purpose
+            return true;
+        }
+        Object value = purposes.get(purpose);
+        for (Object valid : validValues) {
+            if (value == null ? valid == null : value.equals(valid)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Ensures the context specifies the supplied purpose matching against the valid values.
+     *
+     * @param purpose     the purpose.
+     * @param validValues the valid values that the purpose must match.
+     * @return {@code true} if and only if the purpose is specified and is equal to one of the specified values.
+     */
+    public boolean mustHave(@NonNull Object purpose, Object... validValues) {
+        if (purposes == null || !purposes.containsKey(purpose)) {
+            return false;
+        }
+        Object value = purposes.get(purpose);
+        for (Object valid : validValues) {
+            if (value == null ? valid == null : value.equals(valid)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * A non-thread safe builder of {@link AuthenticationTokenContext} instances.
+     *
+     * @param <T> the token type.
+     * @since 1.2
+     */
+    @NotThreadSafe
+    public static final class Builder<T> {
+
+        /**
+         * The token type.
+         */
+        @NonNull
+        private final Class<T> tokenClass;
+        /**
+         * The purposes.
+         */
+        @CheckForNull
+        private Map<Object, Object> purposes = null;
+
+        /**
+         * Constructs a new builder.
+         *
+         * @param tokenClass the token type.
+         */
+        private Builder(@NonNull Class<T> tokenClass) {
+            this.tokenClass = tokenClass;
+        }
+
+        /**
+         * Specifies the supplied purpose (with value {@link Boolean#TRUE}).
+         *
+         * @param purpose the purpose.
+         * @return {@code this} for method chaining.
+         */
+        @NonNull
+        public Builder<T> with(@NonNull Object purpose) {
+            return with(purpose, Boolean.TRUE);
+        }
+
+        /**
+         * Specifies the supplied purpose with the specified value.
+         *
+         * @param purpose the purpose.
+         * @param value   the value.
+         * @return {@code this} for method chaining.
+         */
+        @NonNull
+        public Builder<T> with(@NonNull Object purpose, @CheckForNull Object value) {
+            if (purposes == null) {
+                purposes = new LinkedHashMap<Object, Object>();
+            }
+            purposes.put(purpose, value);
+            return this;
+        }
+
+        /**
+         * Instantiates the {@link AuthenticationTokenContext}.
+         *
+         * @return the {@link AuthenticationTokenContext}.
+         */
+        @NonNull
+        public AuthenticationTokenContext<T> build() {
+            return new AuthenticationTokenContext<T>(tokenClass,
+                    purposes == null || purposes.isEmpty() ? null : purposes);
+        }
+    }
+
+}

--- a/src/main/java/jenkins/authentication/tokens/api/AuthenticationTokenSource.java
+++ b/src/main/java/jenkins/authentication/tokens/api/AuthenticationTokenSource.java
@@ -122,6 +122,27 @@ public abstract class AuthenticationTokenSource<T, C extends Credentials>
     }
 
     /**
+     * Checks if this source fits the specified context.
+     * @param context the context that an authentication token is required in.
+     * @return {@code true} if and only if this source fits the specified context.
+     * @since 1.2
+     */
+    @SuppressWarnings("unchecked")
+    public final boolean fits(AuthenticationTokenContext<?> context) {
+        return produces(context.getTokenClass()) && isFit((AuthenticationTokenContext<? super T>) context);
+    }
+
+    /**
+     * Checks if this source fits the specified context, override this method
+     * @param context the context that an authentication token is required in.
+     * @return {@code true} if and only if this source fits the specified context.
+     * @since 1.2
+     */
+    protected boolean isFit(AuthenticationTokenContext<? super T> context) {
+        return true;
+    }
+
+    /**
      * Score the goodness of match.
      * @param tokenClass the token class.
      * @param credentials the credentials instance.
@@ -155,5 +176,18 @@ public abstract class AuthenticationTokenSource<T, C extends Credentials>
             }
         }
         return ((int)producerScore) << 16 | (int)consumerScore;
+    }
+
+    /**
+     * Score the goodness of match.
+     *
+     * @param context     the context that an authentication token is required in.
+     * @param credentials the credentials instance.
+     * @return the match score (higher the better) or {@code null} if not a match.
+     * @since 1.2
+     */
+    /*package*/
+    final Integer score(AuthenticationTokenContext<?> context, Credentials credentials) {
+        return fits(context) ? score(context.getTokenClass(), credentials) : null;
     }
 }

--- a/src/test/java/jenkins/authentication/tokens/api/AuthenticationTokenContextTest.java
+++ b/src/test/java/jenkins/authentication/tokens/api/AuthenticationTokenContextTest.java
@@ -1,0 +1,204 @@
+package jenkins.authentication.tokens.api;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.impl.CertificateCredentialsImpl;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Util;
+import org.apache.commons.codec.binary.Base64;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Stephen Connolly
+ */
+public class AuthenticationTokenContextTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void smokes() {
+        AuthenticationTokenContext<HttpAuthenticator> context = AuthenticationTokenContext.builder(HttpAuthenticator.class)
+                .build();
+        UsernamePasswordCredentials p =
+                new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "test", null, "bob", "secret");
+        assertThat(AuthenticationTokens.matcher(context).matches(p), is(true));
+        assertThat(AuthenticationTokens.matcher(context).matches(new CertificateCredentialsImpl(CredentialsScope.GLOBAL, "test2", null, null, new CertificateCredentialsImpl.UploadedKeyStoreSource(null))), is(
+                false));
+        
+        HttpAuthenticator authenticator = AuthenticationTokens.convert(context, p);
+        assertThat(authenticator, notNullValue());
+        assertThat(authenticator, instanceOf(HttpAuthenticator.class));
+        assertThat(authenticator.getHeader("foo:"), anyOf(is(Util.getDigestOf("foo:bob:secret")),
+                is(Base64.encodeBase64String("bob:secret".getBytes()))));
+        
+        context = AuthenticationTokenContext.builder(HttpAuthenticator.class)
+                .with(HttpAuthenticator.class, "basic")
+                .build();
+
+        assertThat(AuthenticationTokens.matcher(context).matches(p), is(true));
+        
+        authenticator = AuthenticationTokens.convert(context, p);
+        assertThat(authenticator, notNullValue());
+        assertThat(authenticator, instanceOf(BasicAuthenticator.class));
+        assertThat(authenticator.getHeader("foo:"), is(Base64.encodeBase64String("bob:secret".getBytes())));
+        
+        context = AuthenticationTokenContext.builder(HttpAuthenticator.class)
+                .with(HttpAuthenticator.class, "digest")
+                .build();
+
+        assertThat(AuthenticationTokens.matcher(context).matches(p), is(true));
+        
+        authenticator = AuthenticationTokens.convert(context, p);
+        assertThat(authenticator, notNullValue());
+        assertThat(authenticator, instanceOf(DigestAuthenticator.class));
+        assertThat(authenticator.getHeader("foo:"), is(Util.getDigestOf("foo:bob:secret")));
+        
+        context = AuthenticationTokenContext.builder(HttpAuthenticator.class)
+                .with(HttpAuthenticator.class, "certificate")
+                .build();
+
+        assertThat(AuthenticationTokens.matcher(context).matches(p), is(false));
+        
+        authenticator = AuthenticationTokens.convert(context, p);
+        assertThat(authenticator, nullValue());
+    }
+
+    public interface HttpAuthenticator {
+        String getHeader(String request);
+    }
+    
+    public static class DigestAuthenticator implements HttpAuthenticator {
+        private final String value;
+
+        public DigestAuthenticator(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            DigestAuthenticator that = (DigestAuthenticator) o;
+
+            return !(value != null ? !value.equals(that.value) : that.value != null);
+
+        }
+
+        @Override
+        public int hashCode() {
+            return value != null ? value.hashCode() : 0;
+        }
+
+        @Override
+        public String toString() {
+            final StringBuilder sb = new StringBuilder("DigestAuthenticator{");
+            sb.append("value='").append(value).append('\'');
+            sb.append('}');
+            return sb.toString();
+        }
+
+        public String getHeader(String request) {
+            // we are only running tests, so screw the fact that MD5 is a crappy digest scheme
+            return Util.getDigestOf(request + value);
+        }
+        
+    }
+
+    public static class BasicAuthenticator implements HttpAuthenticator {
+        private final String value;
+
+        public BasicAuthenticator(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            BasicAuthenticator that = (BasicAuthenticator) o;
+
+            return !(value != null ? !value.equals(that.value) : that.value != null);
+
+        }
+
+        @Override
+        public int hashCode() {
+            return value != null ? value.hashCode() : 0;
+        }
+
+        @Override
+        public String toString() {
+            final StringBuilder sb = new StringBuilder("BasicAuthenticator{");
+            sb.append("value='").append(value).append('\'');
+            sb.append('}');
+            return sb.toString();
+        }
+
+        public String getHeader(String request) {
+            // we are only running tests, so screw the fact we are using system encoding
+            return Base64.encodeBase64String(value.getBytes());
+        }
+    }
+
+    @TestExtension
+    public static class UserPassToDigest extends AuthenticationTokenSource<DigestAuthenticator, UsernamePasswordCredentials> {
+
+        public UserPassToDigest() {
+            super(DigestAuthenticator.class, UsernamePasswordCredentials.class);
+        }
+
+        @NonNull
+        @Override
+        public DigestAuthenticator convert(@NonNull UsernamePasswordCredentials credential)
+                throws AuthenticationTokenException {
+            return new DigestAuthenticator(String.format("%s:%s", credential.getUsername(), credential.getPassword().getPlainText()));
+        }
+
+        @Override
+        protected boolean isFit(AuthenticationTokenContext<? super DigestAuthenticator> context) {
+            return context.canHave(HttpAuthenticator.class, "digest");
+        }
+    }
+    
+    @TestExtension
+    public static class UserPassToBasic extends AuthenticationTokenSource<BasicAuthenticator, UsernamePasswordCredentials> {
+
+        public UserPassToBasic() {
+            super(BasicAuthenticator.class, UsernamePasswordCredentials.class);
+        }
+
+        @NonNull
+        @Override
+        public BasicAuthenticator convert(@NonNull UsernamePasswordCredentials credential)
+                throws AuthenticationTokenException {
+            return new BasicAuthenticator(String.format("%s:%s", credential.getUsername(), credential.getPassword().getPlainText()));
+        }
+
+        @Override
+        protected boolean isFit(AuthenticationTokenContext<? super BasicAuthenticator> context) {
+            return context.canHave(HttpAuthenticator.class, "basic");
+        }
+    }
+    
+}


### PR DESCRIPTION
- Filtering token sources (as originally requested in JENKINS-29370) in the consumer of this API is against the spirit of the API.
- The consumer should not be required to know which token sources are valid and which are not valid. If it knew which token sources were valid it would just use them directly.
- The point of this API is to enable the consumer to specify the context within which they want to use the token and then have the credentials (of a type unknown to the consumer) be converted (by a converter of a type unknown to the consumer) into a token (of a type known to the consumer)

@reviewbybees