### PR TITLE
[JENKINS-35287] Upgrade to parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,18 +68,20 @@
     <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.findbugs.failure.strict>true</maven.findbugs.failure.strict>
+    <jenkins.version>1.609.3</jenkins.version>
+    <java.level>6</java.level>
   </properties>
 
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -102,30 +102,6 @@
   </dependencies>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>enforce-maven</id>
-              <goals>
-                <goal>enforce</goal>
-              </goals>
-              <configuration>
-                <rules>
-                  <requireMavenVersion>
-                    <version>(,2.1.0),(2.1.0,2.2.0),(2.2.0,)</version>
-                    <message>Maven 2.1.0 and 2.2.0 produce incorrect GPG signatures and checksums respectively.
-                    </message>
-                  </requireMavenVersion>
-                </rules>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.jenkins-ci.tools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,30 @@
   </dependencies>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>enforce-maven</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <requireMavenVersion>
+                    <version>(,2.1.0),(2.1.0,2.2.0),(2.2.0,)</version>
+                    <message>Maven 2.1.0 and 2.2.0 produce incorrect GPG signatures and checksums respectively.
+                    </message>
+                  </requireMavenVersion>
+                </rules>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.jenkins-ci.tools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -64,11 +64,7 @@
   </scm>
 
   <properties>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.findbugs.failure.strict>true</maven.findbugs.failure.strict>
-    <jenkins.version>1.609.3</jenkins.version>
+    <jenkins.version>1.580.1</jenkins.version>
     <java.level>6</java.level>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.520</version>
+    <version>2.9</version>
   </parent>
 
   <artifactId>authentication-tokens</artifactId>
@@ -56,10 +56,6 @@
     </developer>
   </developers>
 
-  <prerequisites>
-    <maven>2.2.1</maven>
-  </prerequisites>
-
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/authentication-tokens-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/authentication-tokens-plugin.git</developerConnection>
@@ -72,7 +68,6 @@
     <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.findbugs.failure.strict>true</maven.findbugs.failure.strict>
-    <maven-hpi-plugin.version>1.96</maven-hpi-plugin.version>
   </properties>
 
   <repositories>
@@ -89,89 +84,30 @@
   </pluginRepositories>
 
   <dependencies>
-    <!-- regular dependencies -->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
       <version>1.22</version>
-    </dependency>
-    <!-- plugin dependencies -->
-    <!-- jenkins dependencies -->
-    <!-- test dependencies -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.11</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>1.9.5</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <version>1.3.1</version>
-          <executions>
-            <execution>
-              <id>enforce-maven</id>
-              <goals>
-                <goal>enforce</goal>
-              </goals>
-              <configuration>
-                <rules>
-                  <requireMavenVersion>
-                    <version>(,2.1.0),(2.1.0,2.2.0),(2.2.0,)</version>
-                    <message>Maven 2.1.0 and 2.2.0 produce incorrect GPG signatures and checksums respectively.
-                    </message>
-                  </requireMavenVersion>
-                  <requireMavenVersion>
-                    <version>(,3.0),[3.0.4,)</version>
-                    <message>Maven 3.0 through 3.0.3 inclusive do not pass correct settings.xml to Maven Release
-                      Plugin.
-                    </message>
-                  </requireMavenVersion>
-                </rules>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-        <plugin>
-          <artifactId>maven-release-plugin</artifactId>
-          <version>2.5.1</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.1</version>
-        <configuration>
-          <excludeFilterFile>src/findbugs/excludesFilter.xml</excludeFilterFile>
-          <failOnError>${maven.findbugs.failure.strict}</failOnError>
-          <xmlOutput>true</xmlOutput>
-          <findbugsXmlWithMessages>true</findbugsXmlWithMessages>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>verify</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.jenkins-ci.tools</groupId>
         <artifactId>maven-hpi-plugin</artifactId>
-        <version>${maven-hpi-plugin.version}</version>
         <executions>
           <execution>
             <goals>

--- a/src/main/java/jenkins/authentication/tokens/api/AuthenticationTokens.java
+++ b/src/main/java/jenkins/authentication/tokens/api/AuthenticationTokens.java
@@ -28,6 +28,7 @@ import com.cloudbees.plugins.credentials.CredentialsMatcher;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.ExtensionList;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -81,15 +82,7 @@ public final class AuthenticationTokens {
      */
     public static <T> CredentialsMatcher matcher(AuthenticationTokenContext<T> context) {
         List<CredentialsMatcher> matchers = new ArrayList<CredentialsMatcher>();
-        Jenkins jenkins = Jenkins.getInstance();
-        if(jenkins == null){
-            LogRecord lr = new LogRecord(Level.FINE,
-                "No Jenkins object was found; no match could be made.");
-            LOGGER.log(lr);
-            return CredentialsMatchers.never();
-        }
-        for (AuthenticationTokenSource<?, ?> source : jenkins
-                .getExtensionList(AuthenticationTokenSource.class)) {
+        for (AuthenticationTokenSource<?, ?> source : ExtensionList.lookup(AuthenticationTokenSource.class)) {
             if (source.fits(context)) {
                 matchers.add(source.matcher());
             }
@@ -136,15 +129,8 @@ public final class AuthenticationTokens {
         // we want the best match first
         SortedMap<Integer,AuthenticationTokenSource> matches = new TreeMap<Integer, AuthenticationTokenSource>(
                 Collections.reverseOrder());
-        Jenkins jenkins = Jenkins.getInstance();
-        if(jenkins == null){
-            LogRecord lr = new LogRecord(Level.FINE,
-                "No Jenkins object was found; no conversion could be made.");
-            LOGGER.log(lr);
-            return null;
-        }
-        for (AuthenticationTokenSource<?, ?> source : jenkins
-                .getExtensionList(AuthenticationTokenSource.class)) {
+        
+        for (AuthenticationTokenSource<?, ?> source : ExtensionList.lookup(AuthenticationTokenSource.class)) {
             Integer score = source.score(context, credentials);
             if (score != null && !matches.containsKey(score)) {
                 // if there are two extensions with the same score, 

--- a/src/main/java/jenkins/authentication/tokens/api/AuthenticationTokens.java
+++ b/src/main/java/jenkins/authentication/tokens/api/AuthenticationTokens.java
@@ -83,7 +83,9 @@ public final class AuthenticationTokens {
         List<CredentialsMatcher> matchers = new ArrayList<CredentialsMatcher>();
         Jenkins jenkins = Jenkins.getInstance();
         if(jenkins == null){
-            LOGGER.log("No Jenkins object was found; no match could be made.");
+            LogRecord lr = new LogRecord(Level.FINE,
+                "No Jenkins object was found; no match could be made.");
+            LOGGER.log(lr);
             return CredentialsMatchers.never();
         }
         for (AuthenticationTokenSource<?, ?> source : jenkins
@@ -136,7 +138,9 @@ public final class AuthenticationTokens {
                 Collections.reverseOrder());
         Jenkins jenkins = Jenkins.getInstance();
         if(jenkins == null){
-            LOGGER.log("No Jenkins object was found; no conversion could be made.");
+            LogRecord lr = new LogRecord(Level.FINE,
+                "No Jenkins object was found; no conversion could be made.");
+            LOGGER.log(lr);
             return null;
         }
         for (AuthenticationTokenSource<?, ?> source : jenkins
@@ -210,7 +214,9 @@ public final class AuthenticationTokens {
                         
         Jenkins jenkins = Jenkins.getInstance();
         if(jenkins == null){
-            LOGGER.log("No Jenkins object was found; no conversion could be made.");
+            LogRecord lr = new LogRecord(Level.FINE,
+                "No Jenkins object was found; no conversion could be made.");
+            LOGGER.log(lr);
             return null;
         }
         for (C credential : credentials) {

--- a/src/main/java/jenkins/authentication/tokens/api/AuthenticationTokens.java
+++ b/src/main/java/jenkins/authentication/tokens/api/AuthenticationTokens.java
@@ -198,16 +198,8 @@ public final class AuthenticationTokens {
                 new TreeMap<Integer, Map.Entry<C, AuthenticationTokenSource>>(
                         Collections.reverseOrder());
                         
-        Jenkins jenkins = Jenkins.getInstance();
-        if(jenkins == null){
-            LogRecord lr = new LogRecord(Level.FINE,
-                "No Jenkins object was found; no conversion could be made.");
-            LOGGER.log(lr);
-            return null;
-        }
         for (C credential : credentials) {
-            for (AuthenticationTokenSource<?, ?> source : jenkins
-                    .getExtensionList(AuthenticationTokenSource.class)) {
+            for (AuthenticationTokenSource<?, ?> source : ExtensionList.lookup(AuthenticationTokenSource.class)) {
                 Integer score = source.score(context, credential);
                 if (score != null && !matches.containsKey(score)) {
                     // if there are two extensions with the same score,

--- a/src/main/java/jenkins/authentication/tokens/api/AuthenticationTokens.java
+++ b/src/main/java/jenkins/authentication/tokens/api/AuthenticationTokens.java
@@ -81,7 +81,12 @@ public final class AuthenticationTokens {
      */
     public static <T> CredentialsMatcher matcher(AuthenticationTokenContext<T> context) {
         List<CredentialsMatcher> matchers = new ArrayList<CredentialsMatcher>();
-        for (AuthenticationTokenSource<?, ?> source : Jenkins.getInstance()
+        Jenkins jenkins = Jenkins.getInstance();
+        if(jenkins == null){
+            LOGGER.log("No Jenkins object was found; no match could be made.");
+            return CredentialsMatchers.never();
+        }
+        for (AuthenticationTokenSource<?, ?> source : jenkins
                 .getExtensionList(AuthenticationTokenSource.class)) {
             if (source.fits(context)) {
                 matchers.add(source.matcher());
@@ -129,7 +134,12 @@ public final class AuthenticationTokens {
         // we want the best match first
         SortedMap<Integer,AuthenticationTokenSource> matches = new TreeMap<Integer, AuthenticationTokenSource>(
                 Collections.reverseOrder());
-        for (AuthenticationTokenSource<?, ?> source : Jenkins.getInstance()
+        Jenkins jenkins = Jenkins.getInstance();
+        if(jenkins == null){
+            LOGGER.log("No Jenkins object was found; no conversion could be made.");
+            return null;
+        }
+        for (AuthenticationTokenSource<?, ?> source : jenkins
                 .getExtensionList(AuthenticationTokenSource.class)) {
             Integer score = source.score(context, credentials);
             if (score != null && !matches.containsKey(score)) {
@@ -197,8 +207,14 @@ public final class AuthenticationTokens {
         SortedMap<Integer, Map.Entry<C, AuthenticationTokenSource>> matches =
                 new TreeMap<Integer, Map.Entry<C, AuthenticationTokenSource>>(
                         Collections.reverseOrder());
+                        
+        Jenkins jenkins = Jenkins.getInstance();
+        if(jenkins == null){
+            LOGGER.log("No Jenkins object was found; no conversion could be made.");
+            return null;
+        }
         for (C credential : credentials) {
-            for (AuthenticationTokenSource<?, ?> source : Jenkins.getInstance()
+            for (AuthenticationTokenSource<?, ?> source : jenkins
                     .getExtensionList(AuthenticationTokenSource.class)) {
                 Integer score = source.score(context, credential);
                 if (score != null && !matches.containsKey(score)) {


### PR DESCRIPTION
[JENKINS-35287](https://issues.jenkins-ci.org/browse/JENKINS-35287)

Upgrade to new parent pom. More info [here](https://github.com/jenkinsci/plugin-pom).

Moved to parent pom; includes bumping the base to 1.609.3. Bumped versions on hpi-plugin, maven-release, and findbugs.  Removed the enforcer since the parent pom enforces the same set of rules for 3x.  I can add back the rules for 2.x if needed.

@reviewbybees 