### PR TITLE
Upgrade parent pom to 4.40

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,8 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.57</version>
+    <version>4.40</version>
+    <relativePath />
   </parent>
 
   <artifactId>authentication-tokens</artifactId>
@@ -37,9 +38,6 @@
   <packaging>hpi</packaging>
 
   <name>Authentication Tokens API Plugin</name>
-  <description>
-    This plugin provides an API for converting credentials into authentication tokens in Jenkins.
-  </description>
   <url>https://github.com/jenkinsci/authentication-tokens-plugin</url>
   <licenses>
     <license>
@@ -64,8 +62,7 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.176.4</jenkins.version>
-    <java.level>8</java.level>
+    <jenkins.version>2.303.1</jenkins.version>
   </properties>
 
   <repositories>
@@ -81,11 +78,22 @@
     </pluginRepository>
   </pluginRepositories>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.303.x</artifactId>
+        <version>1409.v7659b_c072f18</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>1.22</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<div>
+    This plugin provides an API for converting credentials into authentication tokens in Jenkins.
+</div>

--- a/src/test/java/jenkins/authentication/tokens/api/AuthenticationTokenContextTest.java
+++ b/src/test/java/jenkins/authentication/tokens/api/AuthenticationTokenContextTest.java
@@ -34,7 +34,7 @@ public class AuthenticationTokenContextTest {
                 new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "test", null, "bob", "secret");
         assertThat(AuthenticationTokens.matcher(context).matches(p), is(true));
         CertificateCredentialsImpl q = new CertificateCredentialsImpl(CredentialsScope.GLOBAL, "test2", null, null,
-                new CertificateCredentialsImpl.UploadedKeyStoreSource(null));
+                new CertificateCredentialsImpl.UploadedKeyStoreSource((String) null));
         assertThat(AuthenticationTokens.matcher(context).matches(
                 q), is(
                 false));

--- a/src/test/java/jenkins/authentication/tokens/api/AuthenticationTokensTest.java
+++ b/src/test/java/jenkins/authentication/tokens/api/AuthenticationTokensTest.java
@@ -27,7 +27,7 @@ public class AuthenticationTokensTest {
         UsernamePasswordCredentials p =
                 new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "test", null, "bob", "secret");
         assertThat(AuthenticationTokens.matcher(DigestToken.class).matches(p), is(true));
-        assertThat(AuthenticationTokens.matcher(DigestToken.class).matches(new CertificateCredentialsImpl(CredentialsScope.GLOBAL, "test2", null, null, new CertificateCredentialsImpl.UploadedKeyStoreSource(null))), is(false));
+        assertThat(AuthenticationTokens.matcher(DigestToken.class).matches(new CertificateCredentialsImpl(CredentialsScope.GLOBAL, "test2", null, null, new CertificateCredentialsImpl.UploadedKeyStoreSource((String) null))), is(false));
         assertThat(AuthenticationTokens.convert(DigestToken.class, p),
                 is(new DigestToken(Util.getDigestOf("bob:secret"))));
     }


### PR DESCRIPTION
Hi, this changes are in preparation for testing on Java 17.

- Remove `java.level` - no longer necessary ([release notes](https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.40))
- Rebaseline Jenkins to 2.303.1. According to [the docs](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/), 2.176.4 is no longer supported in the update center.
- Fix deprecations from using a newer core version
- Rely on plugins bom
- Introduce `index.jelly` with description to fix this build failure after upgrade:

```
[ERROR] Failed to execute goal org.jenkins-ci.tools:maven-hpi-plugin:3.27:hpi (default-hpi) on project authentication-tokens: Missing {...}/authentication-tokens-plugin/target/classes/index.jelly. Delete any <description> from pom.xml and create src/main/resources/index.jelly:
[ERROR] <?jelly escape-by-default='true'?>
[ERROR] <div>
[ERROR]     The description here…
[ERROR] </div>
```

Fixes #66
Fixes #71

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue (existing tests work)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
