### PR TITLE
Move Plugin Description to index.jelly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,9 +37,6 @@
   <packaging>hpi</packaging>
 
   <name>Authentication Tokens API Plugin</name>
-  <description>
-    This plugin provides an API for converting credentials into authentication tokens in Jenkins.
-  </description>
   <url>https://github.com/jenkinsci/authentication-tokens-plugin</url>
   <licenses>
     <license>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<div>
+    This plugin provides an API for converting credentials into authentication tokens in Jenkins.
+</div>


### PR DESCRIPTION
According to the [Google Document](https://docs.google.com/document/d/1PKYIpPlRVGsBqrz0Ob1Cv3cefOZ5j2xtGZdWs27kLuw/edit#) provided , <strong>I have created the src/main/resources/index.jelly file and removed the description tag from the pom file </strong> as specified under the <strong>Move plugin description to index.jelly</strong> topic

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira

