### PR TITLE
Use HTTPS SCM URLs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,9 +57,9 @@
   </developers>
 
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/authentication-tokens-plugin.git</connection>
+    <connection>scm:git:https://github.com/jenkinsci/authentication-tokens-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/authentication-tokens-plugin.git</developerConnection>
-    <url>http://github.com/jenkinsci/authentication-tokens-plugin</url>
+    <url>https://github.com/jenkinsci/authentication-tokens-plugin</url>
     <tag>${scmTag}</tag>
   </scm>
 


### PR DESCRIPTION
The old `git://` protocol is [deprecated](https://github.blog/2021-09-01-improving-git-protocol-security-github/).