### PR TITLE
Remove unnecessary customization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,27 +103,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.jenkins-ci.tools</groupId>
-        <artifactId>maven-hpi-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>generate-taglib-interface</id>
-            <goals>
-              <goal>generate-taglib-interface</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <systemProperties>
-            <hudson.bundled.plugins>${basedir}/work/plugins/credentials.hpl</hudson.bundled.plugins>
-          </systemProperties>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>


### PR DESCRIPTION
Unclear why this customization was ever added in the first place, but the tests pass without it, so it seems more prudent to remove this customization and normalize this plugin's configuration.