### PR TITLE
Test with Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,5 +4,6 @@ buildPlugin(
     [platform: 'linux', jdk: '11'],
     [platform: 'windows', jdk: '11'],
     [platform: 'linux', jdk: '17'],
+    [platform: 'linux', jdk: 21],
   ]
 )

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.73</version>
+    <version>4.74</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
   <properties>
     <revision>1</revision>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.387.1</jenkins.version>
+    <jenkins.version>2.387.3</jenkins.version>
   </properties>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.387.x</artifactId>
-        <version>2483.v3b_22f030990a_</version>
+        <version>2496.vddfca_753db_80</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
## Test with Java 21

Java 21 released Sep 19, 2023. We'd like to announce full support for Java 21 in early October and would like the most used plugins to be compiling and testing with Java 21.

The acceptance test harness and plugin bill of materials tests are already passing with Java 21. This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

Java 11 will be unsupported by Eclipse Temurin and some other Java providers in October 2024. We'll need to move past Java 11 by that time.  It does not change the supported Java version or the byte code that is being generated.

Also updates the parent pom to 4.74 (most recent) and the plugin bill of materials to the most recent version.

### Require Jenkins 2.387.3 or newer, not 2.387.1

Use a consistent Jenkins minimum version to match with other plugins and with the recommendations of [choosing a baseline](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/)

[Installation statistics](https://stats.jenkins.io/pluginversions/authentication-tokens.html) show that only 2% of the 61500 installations of the most recent release of the plugin are running on Jenkins prior to 2.387.3.  That's not many users to be inconvenienced by the change, especially since there have been security advisories for Jenkins core since the release of 2.387.1.

A new release is not required based on these changes.  The test configuration update is the most important part of the change.

### Testing done

Confirmed that automated tests pass on Java 21 with Linux.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
